### PR TITLE
fix: resolve --format clap arg-id collision panic on txn import/export

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,11 @@
 cognitive-complexity-threshold = 15
 too-many-arguments-threshold = 6
 too-many-lines-threshold = 100
+
+# `unwrap_used`/`expect_used` are denied for production code (see workspace
+# Cargo.toml) to keep panics out of shipped paths. In test code, `unwrap`/
+# `expect` are the idiomatic way to assert preconditions and fail fast, so
+# exempt tests via clippy's first-class configuration rather than per-call
+# `#[allow]` suppressions.
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "beankeeper-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/README.md
+++ b/README.md
@@ -331,14 +331,14 @@ bk --company personal account list --name "Cash" --with-balances --to 2026-06-30
 
 ### Output Formats
 
-Every command supports `--format table` (default), `--format json`, and `--format csv`. Use `--json` as shorthand:
+Every command supports `--format table` (default), `--format json`, and `--format csv`. The output `--format`/`--json` options are top-level: place them before the subcommand (e.g. `bk --format csv txn list`). Use `--json` as shorthand:
 
 ```sh
 # Pipe JSON to jq (data is inside the envelope's "data" field)
-bk --company personal report trial-balance --json | jq '.data.accounts[] | select(.type == "asset")'
+bk --company personal --json report trial-balance | jq '.data.accounts[] | select(.type == "asset")'
 
 # CSV for spreadsheets
-bk --company personal txn list --format csv > transactions.csv
+bk --company personal --format csv txn list > transactions.csv
 
 # Export entire database (all companies) to JSON
 bk export --json > backup.json

--- a/beankeeper-cli/Cargo.toml
+++ b/beankeeper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beankeeper-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Command-line interface for beankeeper double-entry accounting"

--- a/beankeeper-cli/src/cli.rs
+++ b/beankeeper-cli/src/cli.rs
@@ -52,7 +52,11 @@ pub struct Cli {
 #[derive(Args, Debug)]
 pub struct FormatOptions {
     /// Output format.
-    #[arg(long, global = true, value_enum)]
+    ///
+    /// Defined at the top level only (not `global`) so it does not collide with
+    /// the subcommand-local `--format` options on `export`/`import`, which carry
+    /// their own value enums.
+    #[arg(long, value_enum)]
     pub format: Option<OutputFormat>,
 
     /// Shorthand for --format json.
@@ -157,7 +161,7 @@ EXAMPLES:\n  \
 ")]
     Export {
         /// Output format for export.
-        #[arg(long, value_enum)]
+        #[arg(id = "export_format", long = "format", value_enum)]
         format: Option<ExportFormat>,
 
         /// Output file path (default: stdout).
@@ -331,7 +335,7 @@ EXAMPLES:\n  \
         #[arg(long, conflicts_with_all = ["month", "amount"])]
         annual: Option<String>,
 
-        /// Currency code (default: USD or BEANKEEPER_CURRENCY).
+        /// Currency code (default: USD or `BEANKEEPER_CURRENCY`).
         #[arg(long, env = "BEANKEEPER_CURRENCY", default_value = "USD")]
         currency: String,
 
@@ -783,7 +787,7 @@ EXAMPLES:\n  \
         file: Option<String>,
 
         /// Input format. Auto-detected from file extension when omitted.
-        #[arg(long, value_enum)]
+        #[arg(id = "import_format", long = "format", value_enum)]
         format: Option<ImportFormat>,
 
         /// Validate without persisting.

--- a/beankeeper-cli/src/commands/account.rs
+++ b/beankeeper-cli/src/commands/account.rs
@@ -43,80 +43,110 @@ pub fn run(cli: &Cli, company: &str, sub: &AccountCommand) -> Result<(), CliErro
             }
             render_accounts(&[row], "account.create", company, format, use_color)?;
         }
-        AccountCommand::List {
-            account_type,
-            name,
-            with_balances,
-            from,
-            to,
-        } => {
-            let type_filter = account_type.map(|t| format!("{t:?}").to_lowercase());
-
-            if *with_balances {
-                let rows = db::list_accounts_with_balances(
-                    db.conn(),
-                    company,
-                    type_filter.as_deref(),
-                    name.as_deref(),
-                    from.as_deref(),
-                    to.as_deref(),
-                )?;
-                render_accounts_with_balances(&rows, company, format, use_color)?;
-                if !cli.verbosity.quiet {
-                    let count = rows.len();
-                    eprintln!(
-                        "{count} {noun}",
-                        noun = if count == 1 { "account" } else { "accounts" }
-                    );
-                }
-            } else {
-                let params = accounts::ListAccountParams {
-                    company_slug: company,
-                    type_filter: type_filter.as_deref(),
-                    name_filter: name.as_deref(),
-                };
-                let rows = accounts::list_accounts(db.conn(), &params)?;
-                render_accounts(&rows, "account.list", company, format, use_color)?;
-                if !cli.verbosity.quiet {
-                    let count = rows.len();
-                    eprintln!(
-                        "{count} {noun}",
-                        noun = if count == 1 { "account" } else { "accounts" }
-                    );
-                }
-            }
+        AccountCommand::List { .. } => {
+            run_list(cli, &db, company, sub, format, use_color)?;
         }
         AccountCommand::Show { code } => {
             let row = accounts::get_account(db.conn(), company, code)?;
             render_accounts(&[row], "account.show", company, format, use_color)?;
         }
         AccountCommand::Delete { code, force } => {
-            if !force {
-                if !std::io::stdin().is_terminal() {
-                    return Err(CliError::Usage(
-                        "use --force to confirm deletion when stdin is not a terminal".into(),
-                    ));
-                }
-                eprint!("Delete account '{code}'? [y/N] ");
-                let mut answer = String::new();
-                std::io::stdin().read_line(&mut answer)?;
-                if !answer.trim().eq_ignore_ascii_case("y") {
-                    eprintln!("Aborted.");
-                    return Ok(());
-                }
-            }
-            accounts::delete_account(db.conn(), company, code)?;
-            if format == OutputFormat::Json {
-                let meta = output::json::meta("account.delete", Some(company));
-                let rendered = output::json::render_deleted(code, meta)?;
-                println!("{rendered}");
-            }
-            if !cli.verbosity.quiet {
-                eprintln!("[ok] Deleted account: {code}");
-            }
+            run_delete(cli, &db, company, code, *force, format)?;
         }
     }
 
+    Ok(())
+}
+
+/// Print an account-count summary to stderr unless quiet mode is set.
+fn print_account_count(cli: &Cli, count: usize) {
+    if !cli.verbosity.quiet {
+        eprintln!(
+            "{count} {noun}",
+            noun = if count == 1 { "account" } else { "accounts" }
+        );
+    }
+}
+
+/// Execute the `account list` subcommand.
+fn run_list(
+    cli: &Cli,
+    db: &Db,
+    company: &str,
+    sub: &AccountCommand,
+    format: OutputFormat,
+    use_color: bool,
+) -> Result<(), CliError> {
+    let AccountCommand::List {
+        account_type,
+        name,
+        with_balances,
+        from,
+        to,
+    } = sub
+    else {
+        return Err(CliError::General("expected account list subcommand".into()));
+    };
+
+    let type_filter = account_type.map(|t| format!("{t:?}").to_lowercase());
+
+    if *with_balances {
+        let rows = db::list_accounts_with_balances(
+            db.conn(),
+            company,
+            type_filter.as_deref(),
+            name.as_deref(),
+            from.as_deref(),
+            to.as_deref(),
+        )?;
+        render_accounts_with_balances(&rows, company, format, use_color)?;
+        print_account_count(cli, rows.len());
+    } else {
+        let params = accounts::ListAccountParams {
+            company_slug: company,
+            type_filter: type_filter.as_deref(),
+            name_filter: name.as_deref(),
+        };
+        let rows = accounts::list_accounts(db.conn(), &params)?;
+        render_accounts(&rows, "account.list", company, format, use_color)?;
+        print_account_count(cli, rows.len());
+    }
+
+    Ok(())
+}
+
+/// Execute the `account delete` subcommand.
+fn run_delete(
+    cli: &Cli,
+    db: &Db,
+    company: &str,
+    code: &str,
+    force: bool,
+    format: OutputFormat,
+) -> Result<(), CliError> {
+    if !force {
+        if !std::io::stdin().is_terminal() {
+            return Err(CliError::Usage(
+                "use --force to confirm deletion when stdin is not a terminal".into(),
+            ));
+        }
+        eprint!("Delete account '{code}'? [y/N] ");
+        let mut answer = String::new();
+        std::io::stdin().read_line(&mut answer)?;
+        if !answer.trim().eq_ignore_ascii_case("y") {
+            eprintln!("Aborted.");
+            return Ok(());
+        }
+    }
+    accounts::delete_account(db.conn(), company, code)?;
+    if format == OutputFormat::Json {
+        let meta = output::json::meta("account.delete", Some(company));
+        let rendered = output::json::render_deleted(code, meta)?;
+        println!("{rendered}");
+    }
+    if !cli.verbosity.quiet {
+        eprintln!("[ok] Deleted account: {code}");
+    }
     Ok(())
 }
 

--- a/beankeeper-cli/src/commands/import_ofx.rs
+++ b/beankeeper-cli/src/commands/import_ofx.rs
@@ -293,6 +293,7 @@ fn prepare_transaction(
 }
 
 /// Post one prepared transaction, returning the outcome.
+#[allow(clippy::too_many_arguments)]
 fn post_one(
     conn: &rusqlite::Connection,
     company: &str,
@@ -302,45 +303,9 @@ fn post_one(
     dry_run: bool,
     conflict_strategy: transactions::ConflictStrategy,
 ) -> TransactionOutcome {
-    // Pre-check for duplicates.
-    match reference_exists(conn, company, &prepared.reference) {
-        Ok(true) => {
-            match conflict_strategy {
-                transactions::ConflictStrategy::Error => {
-                    return TransactionOutcome::Failed(FailedTransaction {
-                        date: prepared.date.clone(),
-                        description: prepared.description.clone(),
-                        amount_minor: prepared.amount_minor,
-                        error: format!("duplicate reference: {}", prepared.reference),
-                    });
-                }
-                transactions::ConflictStrategy::Skip => {
-                    return TransactionOutcome::Skipped(SkippedTransaction {
-                        date: prepared.date.clone(),
-                        description: prepared.description.clone(),
-                        amount_minor: prepared.amount_minor,
-                        reference: prepared.reference.clone(),
-                    });
-                }
-                transactions::ConflictStrategy::Upsert => {
-                    return TransactionOutcome::Failed(FailedTransaction {
-                        date: prepared.date.clone(),
-                        description: prepared.description.clone(),
-                        amount_minor: prepared.amount_minor,
-                        error: "on-conflict=upsert not yet implemented".to_string(),
-                    });
-                }
-            }
-        }
-        Ok(false) => {}
-        Err(e) => {
-            return TransactionOutcome::Failed(FailedTransaction {
-                date: prepared.date.clone(),
-                description: prepared.description.clone(),
-                amount_minor: prepared.amount_minor,
-                error: e.to_string(),
-            });
-        }
+    // Pre-check for duplicates; an early outcome means we must not post.
+    if let Some(outcome) = check_conflict(conn, company, prepared, conflict_strategy) {
+        return outcome;
     }
 
     if dry_run {
@@ -353,6 +318,71 @@ fn post_one(
         });
     }
 
+    insert_transaction(
+        conn,
+        company,
+        account_code,
+        suspense_code,
+        prepared,
+        conflict_strategy,
+    )
+}
+
+/// Resolve a pre-existing duplicate reference into an early [`TransactionOutcome`].
+///
+/// Returns `Some(outcome)` when the transaction must not be posted (duplicate
+/// under the active strategy, or a lookup error) and `None` when posting may
+/// proceed.
+fn check_conflict(
+    conn: &rusqlite::Connection,
+    company: &str,
+    prepared: &PreparedTransaction,
+    conflict_strategy: transactions::ConflictStrategy,
+) -> Option<TransactionOutcome> {
+    match reference_exists(conn, company, &prepared.reference) {
+        Ok(true) => Some(match conflict_strategy {
+            transactions::ConflictStrategy::Error => TransactionOutcome::Failed(FailedTransaction {
+                date: prepared.date.clone(),
+                description: prepared.description.clone(),
+                amount_minor: prepared.amount_minor,
+                error: format!("duplicate reference: {}", prepared.reference),
+            }),
+            transactions::ConflictStrategy::Skip => {
+                TransactionOutcome::Skipped(SkippedTransaction {
+                    date: prepared.date.clone(),
+                    description: prepared.description.clone(),
+                    amount_minor: prepared.amount_minor,
+                    reference: prepared.reference.clone(),
+                })
+            }
+            transactions::ConflictStrategy::Upsert => {
+                TransactionOutcome::Failed(FailedTransaction {
+                    date: prepared.date.clone(),
+                    description: prepared.description.clone(),
+                    amount_minor: prepared.amount_minor,
+                    error: "on-conflict=upsert not yet implemented".to_string(),
+                })
+            }
+        }),
+        Ok(false) => None,
+        Err(e) => Some(TransactionOutcome::Failed(FailedTransaction {
+            date: prepared.date.clone(),
+            description: prepared.description.clone(),
+            amount_minor: prepared.amount_minor,
+            error: e.to_string(),
+        })),
+    }
+}
+
+/// Build the balanced double-entry pair and post the prepared transaction.
+fn insert_transaction(
+    conn: &rusqlite::Connection,
+    company: &str,
+    account_code: &str,
+    suspense_code: &str,
+    prepared: &PreparedTransaction,
+    conflict_strategy: transactions::ConflictStrategy,
+) -> TransactionOutcome {
     // Build balanced entries: inflow = debit bank, credit suspense;
     // outflow = debit suspense, credit bank.
     let (debit_code, credit_code) = if prepared.is_inflow {

--- a/beankeeper-cli/src/commands/init.rs
+++ b/beankeeper-cli/src/commands/init.rs
@@ -79,6 +79,7 @@ pub fn run(
 // Helper – shorthand for posting a transaction, returning its ID
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn post(
     conn: &rusqlite::Connection,
     company: &str,
@@ -179,13 +180,22 @@ fn dr_memo(code: &str, amount: i64, memo: &str) -> PostEntryParams {
 /// - acme-consulting pays acme-products for software licences
 /// - acme-consulting pays the owner (salary draw to personal)
 fn populate_demo_data(db: &Db) -> Result<(), CliError> {
-    use crate::db::{create_account, create_company};
-
     let conn = db.conn();
 
-    // =====================================================================
-    // Companies
-    // =====================================================================
+    seed_companies(conn)?;
+    seed_accounts(conn)?;
+    seed_consulting_transactions(conn)?;
+    seed_products_transactions(conn)?;
+    seed_personal_transactions(conn)?;
+    seed_intercompany_transactions(conn)?;
+
+    Ok(())
+}
+
+/// Create the three demo companies.
+fn seed_companies(conn: &rusqlite::Connection) -> Result<(), CliError> {
+    use crate::db::create_company;
+
     create_company(
         conn,
         "acme-consulting",
@@ -205,284 +215,108 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         Some("Owner personal finances"),
     )?;
 
-    // =====================================================================
-    // Chart of Accounts – acme-consulting
-    // =====================================================================
-    create_account(
-        conn,
-        "acme-consulting",
-        "1000",
-        "Operating Cash",
-        "asset",
-        None,
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "1100",
-        "Accounts Receivable",
-        "asset",
-        None,
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "1500",
-        "Due from Acme Products",
-        "asset",
-        None,
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "2000",
-        "Accounts Payable",
-        "liability",
-        None,
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "2500",
-        "Due to Owner",
-        "liability",
-        None,
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "3000",
-        "Owner Equity",
-        "equity",
-        None,
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "4000",
-        "Consulting Revenue",
-        "revenue",
-        Some("income"),
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "5000",
-        "Rent Expense",
-        "expense",
-        Some("rent"),
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "5100",
-        "Software Licences",
-        "expense",
-        Some("software"),
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "5200",
-        "Office Supplies",
-        "expense",
-        Some("supplies"),
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "5300",
-        "Salary Expense",
-        "expense",
-        Some("payroll"),
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "2600",
-        "Federal Tax Payable",
-        "liability",
-        Some("payroll-tax"),
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "2700",
-        "State Tax Payable",
-        "liability",
-        Some("payroll-tax"),
-    )?;
-    create_account(
-        conn,
-        "acme-consulting",
-        "2800",
-        "FICA Payable",
-        "liability",
-        Some("payroll-tax"),
-    )?;
+    Ok(())
+}
 
-    // =====================================================================
-    // Chart of Accounts – acme-products
-    // =====================================================================
-    create_account(
-        conn,
-        "acme-products",
-        "1000",
-        "Operating Cash",
-        "asset",
-        None,
-    )?;
-    create_account(
-        conn,
-        "acme-products",
-        "1100",
-        "Accounts Receivable",
-        "asset",
-        None,
-    )?;
-    create_account(conn, "acme-products", "1200", "Inventory", "asset", None)?;
-    create_account(
-        conn,
-        "acme-products",
-        "1500",
-        "Due from Acme Consulting",
-        "asset",
-        None,
-    )?;
-    create_account(
-        conn,
-        "acme-products",
-        "2000",
-        "Accounts Payable",
-        "liability",
-        None,
-    )?;
-    create_account(
-        conn,
-        "acme-products",
-        "3000",
-        "Owner Equity",
-        "equity",
-        None,
-    )?;
-    create_account(
-        conn,
-        "acme-products",
-        "4000",
-        "Product Sales",
-        "revenue",
-        Some("income"),
-    )?;
-    create_account(
-        conn,
-        "acme-products",
-        "4100",
-        "Licence Revenue",
-        "revenue",
-        Some("income"),
-    )?;
-    create_account(
-        conn,
-        "acme-products",
-        "5000",
-        "Cost of Goods Sold",
-        "expense",
-        Some("cogs"),
-    )?;
-    create_account(
-        conn,
-        "acme-products",
-        "5100",
-        "Shipping Expense",
-        "expense",
-        Some("shipping"),
-    )?;
+/// Create the chart of accounts for all three demo companies.
+fn seed_accounts(conn: &rusqlite::Connection) -> Result<(), CliError> {
+    seed_consulting_accounts(conn)?;
+    seed_products_accounts(conn)?;
+    seed_personal_accounts(conn)?;
+    Ok(())
+}
 
-    // =====================================================================
-    // Chart of Accounts – personal
-    // =====================================================================
-    create_account(conn, "personal", "1000", "Checking Account", "asset", None)?;
-    create_account(conn, "personal", "1100", "Savings Account", "asset", None)?;
-    create_account(
-        conn,
-        "personal",
-        "1500",
-        "Due from Acme Consulting",
-        "asset",
-        None,
-    )?;
-    create_account(conn, "personal", "2000", "Credit Card", "liability", None)?;
-    create_account(conn, "personal", "3000", "Net Worth", "equity", None)?;
-    create_account(
-        conn,
-        "personal",
-        "4000",
-        "Salary Income",
-        "revenue",
-        Some("w2-income"),
-    )?;
-    create_account(
-        conn,
-        "personal",
-        "4100",
-        "Investment Income",
-        "revenue",
-        Some("investment"),
-    )?;
-    create_account(conn, "personal", "5000", "Rent", "expense", Some("housing"))?;
-    create_account(
-        conn,
-        "personal",
-        "5100",
-        "Groceries",
-        "expense",
-        Some("food"),
-    )?;
-    create_account(
-        conn,
-        "personal",
-        "5200",
-        "Utilities",
-        "expense",
-        Some("utilities"),
-    )?;
-    create_account(
-        conn,
-        "personal",
-        "5300",
-        "Federal Tax Withheld",
-        "expense",
-        Some("fed-tax"),
-    )?;
-    create_account(
-        conn,
-        "personal",
-        "5400",
-        "State Tax Withheld",
-        "expense",
-        Some("state-tax"),
-    )?;
-    create_account(
-        conn,
-        "personal",
-        "5500",
-        "FICA Withheld",
-        "expense",
-        Some("fica"),
-    )?;
+/// Create a company's chart of accounts from `(code, name, type, tax)` rows.
+fn seed_company_accounts(
+    conn: &rusqlite::Connection,
+    company: &str,
+    accounts: &[(&str, &str, &str, Option<&str>)],
+) -> Result<(), CliError> {
+    use crate::db::create_account;
 
-    // =====================================================================
-    // Transactions – acme-consulting
-    // =====================================================================
+    for &(code, name, account_type, tax) in accounts {
+        create_account(conn, company, code, name, account_type, tax)?;
+    }
+    Ok(())
+}
 
+/// Create the acme-consulting chart of accounts.
+fn seed_consulting_accounts(conn: &rusqlite::Connection) -> Result<(), CliError> {
+    // Chart of Accounts – acme-consulting. `(code, name, type, tax_category)`.
+    let accounts: &[(&str, &str, &str, Option<&str>)] = &[
+        ("1000", "Operating Cash", "asset", None),
+        ("1100", "Accounts Receivable", "asset", None),
+        ("1500", "Due from Acme Products", "asset", None),
+        ("2000", "Accounts Payable", "liability", None),
+        ("2500", "Due to Owner", "liability", None),
+        ("3000", "Owner Equity", "equity", None),
+        ("4000", "Consulting Revenue", "revenue", Some("income")),
+        ("5000", "Rent Expense", "expense", Some("rent")),
+        ("5100", "Software Licences", "expense", Some("software")),
+        ("5200", "Office Supplies", "expense", Some("supplies")),
+        ("5300", "Salary Expense", "expense", Some("payroll")),
+        ("2600", "Federal Tax Payable", "liability", Some("payroll-tax")),
+        ("2700", "State Tax Payable", "liability", Some("payroll-tax")),
+        ("2800", "FICA Payable", "liability", Some("payroll-tax")),
+    ];
+    seed_company_accounts(conn, "acme-consulting", accounts)?;
+
+    Ok(())
+}
+
+/// Create the acme-products chart of accounts.
+fn seed_products_accounts(conn: &rusqlite::Connection) -> Result<(), CliError> {
+    // Chart of Accounts – acme-products. `(code, name, type, tax_category)`.
+    let accounts: &[(&str, &str, &str, Option<&str>)] = &[
+        ("1000", "Operating Cash", "asset", None),
+        ("1100", "Accounts Receivable", "asset", None),
+        ("1200", "Inventory", "asset", None),
+        ("1500", "Due from Acme Consulting", "asset", None),
+        ("2000", "Accounts Payable", "liability", None),
+        ("3000", "Owner Equity", "equity", None),
+        ("4000", "Product Sales", "revenue", Some("income")),
+        ("4100", "Licence Revenue", "revenue", Some("income")),
+        ("5000", "Cost of Goods Sold", "expense", Some("cogs")),
+        ("5100", "Shipping Expense", "expense", Some("shipping")),
+    ];
+    seed_company_accounts(conn, "acme-products", accounts)?;
+
+    Ok(())
+}
+
+/// Create the personal-books chart of accounts.
+fn seed_personal_accounts(conn: &rusqlite::Connection) -> Result<(), CliError> {
+    // Chart of Accounts – personal. `(code, name, type, tax_category)`.
+    let accounts: &[(&str, &str, &str, Option<&str>)] = &[
+        ("1000", "Checking Account", "asset", None),
+        ("1100", "Savings Account", "asset", None),
+        ("1500", "Due from Acme Consulting", "asset", None),
+        ("2000", "Credit Card", "liability", None),
+        ("3000", "Net Worth", "equity", None),
+        ("4000", "Salary Income", "revenue", Some("w2-income")),
+        ("4100", "Investment Income", "revenue", Some("investment")),
+        ("5000", "Rent", "expense", Some("housing")),
+        ("5100", "Groceries", "expense", Some("food")),
+        ("5200", "Utilities", "expense", Some("utilities")),
+        ("5300", "Federal Tax Withheld", "expense", Some("fed-tax")),
+        ("5400", "State Tax Withheld", "expense", Some("state-tax")),
+        ("5500", "FICA Withheld", "expense", Some("fica")),
+    ];
+    seed_company_accounts(conn, "personal", accounts)?;
+
+    Ok(())
+}
+
+/// Seed the acme-consulting demo transactions.
+fn seed_consulting_transactions(conn: &rusqlite::Connection) -> Result<(), CliError> {
     // C1. Owner invests $25,000 into consulting LLC
-    let c1 = post(
+    let _c1 = post(
         conn,
         "acme-consulting",
         "Owner capital contribution",
         "USD",
         "2025-01-01",
-        &[dr("1000", 25_000_00), cr("3000", 25_000_00)],
+        &[dr("1000", 2_500_000), cr("3000", 2_500_000)],
         "AC-001",
         None,
     )?;
@@ -494,7 +328,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "January office rent",
         "USD",
         "2025-01-05",
-        &[dr_tax("5000", 2_500_00, "rent"), cr("1000", 2_500_00)],
+        &[dr_tax("5000", 250_000, "rent"), cr("1000", 250_000)],
         "AC-002",
         None,
     )?;
@@ -506,7 +340,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Invoice #101 - Globex Corp",
         "USD",
         "2025-01-15",
-        &[dr("1100", 12_000_00), cr_tax("4000", 12_000_00, "income")],
+        &[dr("1100", 1_200_000), cr_tax("4000", 1_200_000, "income")],
         "AC-003",
         None,
     )?;
@@ -518,7 +352,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Payment from Globex Corp",
         "USD",
         "2025-01-28",
-        &[dr("1000", 12_000_00), cr("1100", 12_000_00)],
+        &[dr("1000", 1_200_000), cr("1100", 1_200_000)],
         "AC-004",
         None,
     )?;
@@ -530,7 +364,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Office supplies - paper and toner",
         "USD",
         "2025-02-03",
-        &[dr_tax("5200", 275_00, "supplies"), cr("1000", 275_00)],
+        &[dr_tax("5200", 27_500, "supplies"), cr("1000", 27_500)],
         "AC-005",
         None,
     )?;
@@ -542,7 +376,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Invoice #102 - Initech",
         "USD",
         "2025-02-15",
-        &[dr("1100", 8_500_00), cr_tax("4000", 8_500_00, "income")],
+        &[dr("1100", 850_000), cr_tax("4000", 850_000, "income")],
         "AC-006",
         None,
     )?;
@@ -554,23 +388,24 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "February office rent",
         "USD",
         "2025-02-05",
-        &[dr_tax("5000", 2_500_00, "rent"), cr("1000", 2_500_00)],
+        &[dr_tax("5000", 250_000, "rent"), cr("1000", 250_000)],
         "AC-007",
         None,
     )?;
 
-    // =====================================================================
-    // Transactions – acme-products
-    // =====================================================================
+    Ok(())
+}
 
+/// Seed the acme-products demo transactions.
+fn seed_products_transactions(conn: &rusqlite::Connection) -> Result<(), CliError> {
     // P1. Owner invests $15,000 into products company
-    let p1 = post(
+    let _p1 = post(
         conn,
         "acme-products",
         "Owner capital contribution",
         "USD",
         "2025-01-01",
-        &[dr("1000", 15_000_00), cr("3000", 15_000_00)],
+        &[dr("1000", 1_500_000), cr("3000", 1_500_000)],
         "AP-001",
         None,
     )?;
@@ -583,8 +418,8 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "USD",
         "2025-01-08",
         &[
-            dr_memo("1200", 5_000_00, "500 widgets @ $10"),
-            cr("1000", 5_000_00),
+            dr_memo("1200", 500_000, "500 widgets @ $10"),
+            cr("1000", 500_000),
         ],
         "AP-002",
         None,
@@ -597,7 +432,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Widget sale - 100 units",
         "USD",
         "2025-01-20",
-        &[dr("1100", 2_500_00), cr_tax("4000", 2_500_00, "income")],
+        &[dr("1100", 250_000), cr_tax("4000", 250_000, "income")],
         "AP-003",
         None,
     )?;
@@ -609,7 +444,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "COGS - 100 widgets sold",
         "USD",
         "2025-01-20",
-        &[dr_tax("5000", 1_000_00, "cogs"), cr("1200", 1_000_00)],
+        &[dr_tax("5000", 100_000, "cogs"), cr("1200", 100_000)],
         "AP-004",
         None,
     )?;
@@ -621,7 +456,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Payment received - widget sale",
         "USD",
         "2025-02-01",
-        &[dr("1000", 2_500_00), cr("1100", 2_500_00)],
+        &[dr("1000", 250_000), cr("1100", 250_000)],
         "AP-005",
         None,
     )?;
@@ -633,15 +468,16 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Shipping costs - January",
         "USD",
         "2025-01-31",
-        &[dr_tax("5100", 350_00, "shipping"), cr("1000", 350_00)],
+        &[dr_tax("5100", 35_000, "shipping"), cr("1000", 35_000)],
         "AP-006",
         None,
     )?;
 
-    // =====================================================================
-    // Transactions – personal
-    // =====================================================================
+    Ok(())
+}
 
+/// Seed the personal-books demo transactions.
+fn seed_personal_transactions(conn: &rusqlite::Connection) -> Result<(), CliError> {
     // R1. Starting balance (savings)
     post(
         conn,
@@ -649,7 +485,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Opening balance - savings",
         "USD",
         "2025-01-01",
-        &[dr("1100", 50_000_00), cr("3000", 50_000_00)],
+        &[dr("1100", 5_000_000), cr("3000", 5_000_000)],
         "PR-001",
         None,
     )?;
@@ -661,7 +497,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Opening balance - checking",
         "USD",
         "2025-01-01",
-        &[dr("1000", 5_000_00), cr("3000", 5_000_00)],
+        &[dr("1000", 500_000), cr("3000", 500_000)],
         "PR-002",
         None,
     )?;
@@ -673,7 +509,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "January apartment rent",
         "USD",
         "2025-01-03",
-        &[dr_tax("5000", 1_800_00, "housing"), cr("1000", 1_800_00)],
+        &[dr_tax("5000", 180_000, "housing"), cr("1000", 180_000)],
         "PR-003",
         None,
     )?;
@@ -685,7 +521,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Weekly groceries",
         "USD",
         "2025-01-07",
-        &[dr_tax("5100", 185_50, "food"), cr("2000", 185_50)],
+        &[dr_tax("5100", 18_550, "food"), cr("2000", 18_550)],
         "PR-004",
         None,
     )?;
@@ -697,7 +533,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Electric and internet",
         "USD",
         "2025-01-15",
-        &[dr_tax("5200", 210_00, "utilities"), cr("1000", 210_00)],
+        &[dr_tax("5200", 21_000, "utilities"), cr("1000", 21_000)],
         "PR-005",
         None,
     )?;
@@ -709,7 +545,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "February apartment rent",
         "USD",
         "2025-02-03",
-        &[dr_tax("5000", 1_800_00, "housing"), cr("1000", 1_800_00)],
+        &[dr_tax("5000", 180_000, "housing"), cr("1000", 180_000)],
         "PR-006",
         None,
     )?;
@@ -721,15 +557,16 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Quarterly dividend - index fund",
         "USD",
         "2025-01-31",
-        &[dr("1100", 320_00), cr_tax("4100", 320_00, "investment")],
+        &[dr("1100", 32_000), cr_tax("4100", 32_000, "investment")],
         "PR-007",
         None,
     )?;
 
-    // =====================================================================
-    // Intercompany transactions (mirror pairs with correlation)
-    // =====================================================================
+    Ok(())
+}
 
+/// Seed the intercompany demo transactions (mirror pairs with correlation).
+fn seed_intercompany_transactions(conn: &rusqlite::Connection) -> Result<(), CliError> {
     // IC1. Owner funds acme-consulting from personal savings
     //   personal side: savings down, receivable from consulting up
     //   consulting side: already recorded as C1 above — but that was equity.
@@ -740,7 +577,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Loan to Acme Consulting",
         "USD",
         "2025-01-02",
-        &[dr("1500", 5_000_00), cr("1100", 5_000_00)],
+        &[dr("1500", 500_000), cr("1100", 500_000)],
         "IC-001-P",
         None,
     )?;
@@ -750,7 +587,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Loan from owner (personal)",
         "USD",
         "2025-01-02",
-        &[dr("1000", 5_000_00), cr("2500", 5_000_00)],
+        &[dr("1000", 500_000), cr("2500", 500_000)],
         "IC-001-C",
         Some(ic1_personal),
     )?;
@@ -764,7 +601,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Software licences from Acme Products",
         "USD",
         "2025-02-01",
-        &[dr_tax("5100", 3_600_00, "software"), cr("2000", 3_600_00)],
+        &[dr_tax("5100", 360_000, "software"), cr("2000", 360_000)],
         "IC-002-C",
         None,
     )?;
@@ -774,7 +611,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Licence sale to Acme Consulting",
         "USD",
         "2025-02-01",
-        &[dr("1500", 3_600_00), cr_tax("4100", 3_600_00, "income")],
+        &[dr("1500", 360_000), cr_tax("4100", 360_000, "income")],
         "IC-002-P",
         Some(ic2_consulting),
     )?;
@@ -809,11 +646,11 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "USD",
         "2025-02-15",
         &[
-            dr_tax("5300", 5_000_00, "payroll"),
-            cr_tax("2600", 600_00, "payroll-tax"),
-            cr_tax("2700", 250_00, "payroll-tax"),
-            cr_tax("2800", 382_50, "payroll-tax"),
-            cr("1000", 3_767_50),
+            dr_tax("5300", 500_000, "payroll"),
+            cr_tax("2600", 60_000, "payroll-tax"),
+            cr_tax("2700", 25_000, "payroll-tax"),
+            cr_tax("2800", 38_250, "payroll-tax"),
+            cr("1000", 376_750),
         ],
         "IC-003-C",
         None,
@@ -825,11 +662,11 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "USD",
         "2025-02-15",
         &[
-            dr("1000", 3_767_50),
-            dr_tax("5300", 600_00, "fed-tax"),
-            dr_tax("5400", 250_00, "state-tax"),
-            dr_tax("5500", 382_50, "fica"),
-            cr_tax("4000", 5_000_00, "w2-income"),
+            dr("1000", 376_750),
+            dr_tax("5300", 60_000, "fed-tax"),
+            dr_tax("5400", 25_000, "state-tax"),
+            dr_tax("5500", 38_250, "fica"),
+            cr_tax("4000", 500_000, "w2-income"),
         ],
         "IC-003-P",
         Some(ic3_consulting),
@@ -844,7 +681,7 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Payment to Acme Products - licence invoice",
         "USD",
         "2025-02-20",
-        &[dr("2000", 3_600_00), cr("1000", 3_600_00)],
+        &[dr("2000", 360_000), cr("1000", 360_000)],
         "IC-004-C",
         None,
     )?;
@@ -854,14 +691,10 @@ fn populate_demo_data(db: &Db) -> Result<(), CliError> {
         "Payment from Acme Consulting",
         "USD",
         "2025-02-20",
-        &[dr("1000", 3_600_00), cr("1500", 3_600_00)],
+        &[dr("1000", 360_000), cr("1500", 360_000)],
         "IC-004-P",
         Some(ic4_consulting),
     )?;
-
-    // Suppress unused variable warnings for clarity — the IDs are used by
-    // the correlate mechanism at post time, we just don't need them after.
-    let _ = (c1, p1);
 
     Ok(())
 }

--- a/beankeeper-cli/src/commands/report.rs
+++ b/beankeeper-cli/src/commands/report.rs
@@ -711,14 +711,26 @@ fn run_budget_variance(
     Ok(())
 }
 
-/// Build a title for the budget-variance report.
-fn build_variance_title(currency: &str, year: i32, from_month: i32, to_month: i32) -> String {
+/// Return the three-letter English name for a 1-based month number.
+///
+/// Out-of-range inputs (outside `1..=12`) fall back to `"?"` rather than
+/// panicking on an out-of-bounds index or a sign-losing cast.
+fn month_name(month: i32) -> &'static str {
     static MONTH_NAMES: [&str; 12] = [
         "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
     ];
 
-    let from_name = MONTH_NAMES[(from_month - 1) as usize];
-    let to_name = MONTH_NAMES[(to_month - 1) as usize];
+    usize::try_from(month - 1)
+        .ok()
+        .and_then(|i| MONTH_NAMES.get(i))
+        .copied()
+        .unwrap_or("?")
+}
+
+/// Build a title for the budget-variance report.
+fn build_variance_title(currency: &str, year: i32, from_month: i32, to_month: i32) -> String {
+    let from_name = month_name(from_month);
+    let to_name = month_name(to_month);
 
     if from_month == to_month {
         format!("Budget vs. Actual -- {year} {from_name} ({currency})")

--- a/beankeeper-cli/src/commands/txn.rs
+++ b/beankeeper-cli/src/commands/txn.rs
@@ -67,51 +67,8 @@ pub fn run(
             transaction_id,
             entry,
             status,
-        } => run_clear(cli, &db_handle, company, *transaction_id, *entry, status, meta),
-        TxnCommand::Import {
-            file,
-            format: import_format,
-            dry_run,
-            account,
-            suspense,
-            on_conflict,
-        } => {
-            let effective_format = match import_format {
-                Some(f) => *f,
-                None => match file.as_deref() {
-                    Some(path) if path != "-" => crate::commands::import_ofx::detect_format(path)?,
-                    _ => {
-                        return Err(CliError::Usage(
-                            "cannot detect format from stdin; specify --format".into(),
-                        ));
-                    }
-                },
-            };
-
-            match effective_format {
-                crate::cli::ImportFormat::Ofx => {
-                    let acct = account
-                        .as_deref()
-                        .ok_or(crate::commands::import_ofx::OfxImportError::MissingAccountFlag)?;
-                    let susp = suspense
-                        .as_deref()
-                        .ok_or(crate::commands::import_ofx::OfxImportError::MissingSuspenseFlag)?;
-                    crate::commands::import_ofx::run_import_ofx(
-                        cli,
-                        &db_handle,
-                        company,
-                        file.as_deref(),
-                        acct,
-                        susp,
-                        *dry_run,
-                        *on_conflict,
-                    )
-                }
-                crate::cli::ImportFormat::Csv | crate::cli::ImportFormat::Json => Err(
-                    CliError::General(format!("{effective_format:?} import not yet implemented")),
-                ),
-            }
-        }
+        } => run_clear(cli, &db_handle, company, *transaction_id, *entry, *status, meta),
+        TxnCommand::Import { .. } => run_import(cli, &db_handle, company, sub),
         TxnCommand::Attach {
             transaction_id,
             file_path,
@@ -127,6 +84,57 @@ pub fn run(
             *entry,
         ),
         TxnCommand::Reconcile => run_reconcile(cli, &db_handle, format, use_color),
+    }
+}
+
+/// Execute the `txn import` subcommand.
+fn run_import(cli: &Cli, db_handle: &Db, company: &str, sub: &TxnCommand) -> Result<(), CliError> {
+    let TxnCommand::Import {
+        file,
+        format: import_format,
+        dry_run,
+        account,
+        suspense,
+        on_conflict,
+    } = sub
+    else {
+        return Err(CliError::General("expected txn import subcommand".into()));
+    };
+
+    let effective_format = match import_format {
+        Some(f) => *f,
+        None => match file.as_deref() {
+            Some(path) if path != "-" => crate::commands::import_ofx::detect_format(path)?,
+            _ => {
+                return Err(CliError::Usage(
+                    "cannot detect format from stdin; specify --format".into(),
+                ));
+            }
+        },
+    };
+
+    match effective_format {
+        crate::cli::ImportFormat::Ofx => {
+            let acct = account
+                .as_deref()
+                .ok_or(crate::commands::import_ofx::OfxImportError::MissingAccountFlag)?;
+            let susp = suspense
+                .as_deref()
+                .ok_or(crate::commands::import_ofx::OfxImportError::MissingSuspenseFlag)?;
+            crate::commands::import_ofx::run_import_ofx(
+                cli,
+                db_handle,
+                company,
+                file.as_deref(),
+                acct,
+                susp,
+                *dry_run,
+                *on_conflict,
+            )
+        }
+        crate::cli::ImportFormat::Csv | crate::cli::ImportFormat::Json => Err(CliError::General(
+            format!("{effective_format:?} import not yet implemented"),
+        )),
     }
 }
 
@@ -439,7 +447,7 @@ fn run_post(
         match post_result {
             transactions::PostResult::Created(id) => eprintln!("[ok] transaction #{id} posted"),
             transactions::PostResult::Skipped(id) => {
-                eprintln!("[skipped] duplicate reference; transaction already exists (id: {id})")
+                eprintln!("[skipped] duplicate reference; transaction already exists (id: {id})");
             }
         }
     }
@@ -575,8 +583,7 @@ fn run_show(
 
     // Determine currency minor units for formatting
     let currency_minor_units = Currency::from_code(&txn.currency)
-        .map(|c| c.minor_units())
-        .unwrap_or(2);
+        .map_or(2, |c| c.minor_units());
 
     match format {
         OutputFormat::Table => {
@@ -681,13 +688,14 @@ fn run_attach(
 }
 
 /// Execute the `txn clear` subcommand.
+#[allow(clippy::too_many_arguments)]
 fn run_clear(
     cli: &Cli,
     db_handle: &Db,
     company: &str,
     transaction_id: i64,
     entry_id: i64,
-    status: &crate::cli::ClearanceArg,
+    status: crate::cli::ClearanceArg,
     meta: Option<output::json::Meta>,
 ) -> Result<(), CliError> {
     // 1. Verify transaction and entry exist.

--- a/beankeeper-cli/src/db/budgets.rs
+++ b/beankeeper-cli/src/db/budgets.rs
@@ -496,7 +496,7 @@ mod tests {
         SetAnnualBudgetParams { company_slug: "acme", account_code: account, currency: "USD", year, annual_amount: amount, notes }
     }
 
-    fn variance<'a>(year: i32, from: i32, to: i32, acct_type: Option<&'a str>, unbudgeted: bool) -> BudgetVarianceParams<'a> {
+    fn variance(year: i32, from: i32, to: i32, acct_type: Option<&str>, unbudgeted: bool) -> BudgetVarianceParams<'_> {
         BudgetVarianceParams { company_slug: "acme", currency: "USD", year, from_month: from, to_month: to, account_type: acct_type, include_unbudgeted: unbudgeted }
     }
 

--- a/beankeeper-cli/src/db/schema.rs
+++ b/beankeeper-cli/src/db/schema.rs
@@ -404,15 +404,14 @@ mod tests {
         // Verify the reference column exists by querying pragma
         let has_reference: bool = conn
             .prepare("PRAGMA table_info(transactions)")
-            .map(|mut stmt| {
+            .is_ok_and(|mut stmt| {
                 let names: Vec<String> = stmt
                     .query_map([], |row| row.get::<_, String>(1))
                     .unwrap_or_else(|e| panic!("query failed: {e}"))
                     .filter_map(Result::ok)
                     .collect();
                 names.contains(&"reference".to_string())
-            })
-            .unwrap_or(false);
+            });
         assert!(
             has_reference,
             "reference column should exist after v3 migration"
@@ -435,15 +434,14 @@ mod tests {
         // Verify tax_category column on entries
         let has_tax_category: bool = conn
             .prepare("PRAGMA table_info(entries)")
-            .map(|mut stmt| {
+            .is_ok_and(|mut stmt| {
                 let names: Vec<String> = stmt
                     .query_map([], |row| row.get::<_, String>(1))
                     .unwrap_or_else(|e| panic!("query failed: {e}"))
                     .filter_map(Result::ok)
                     .collect();
                 names.contains(&"tax_category".to_string())
-            })
-            .unwrap_or(false);
+            });
         assert!(
             has_tax_category,
             "tax_category column should exist on entries after v4"
@@ -452,15 +450,14 @@ mod tests {
         // Verify default_tax_category column on accounts
         let has_default_tax: bool = conn
             .prepare("PRAGMA table_info(accounts)")
-            .map(|mut stmt| {
+            .is_ok_and(|mut stmt| {
                 let names: Vec<String> = stmt
                     .query_map([], |row| row.get::<_, String>(1))
                     .unwrap_or_else(|e| panic!("query failed: {e}"))
                     .filter_map(Result::ok)
                     .collect();
                 names.contains(&"default_tax_category".to_string())
-            })
-            .unwrap_or(false);
+            });
         assert!(
             has_default_tax,
             "default_tax_category column should exist on accounts after v4"
@@ -548,15 +545,14 @@ mod tests {
         // Verify status column on entries
         let has_status: bool = conn
             .prepare("PRAGMA table_info(entries)")
-            .map(|mut stmt| {
+            .is_ok_and(|mut stmt| {
                 let names: Vec<String> = stmt
                     .query_map([], |row| row.get::<_, String>(1))
                     .unwrap_or_else(|e| panic!("query failed: {e}"))
                     .filter_map(Result::ok)
                     .collect();
                 names.contains(&"status".to_string())
-            })
-            .unwrap_or(false);
+            });
         assert!(
             has_status,
             "status column should exist on entries after v6"

--- a/beankeeper-cli/tests/format_arg_collision.rs
+++ b/beankeeper-cli/tests/format_arg_collision.rs
@@ -1,0 +1,119 @@
+//! Integration tests for the `--format` clap argument-id collision.
+//!
+//! Reproduces GitHub issue #10: the top-level output `--format` option was
+//! declared `global = true`, so its clap argument id (`format`) was propagated
+//! onto every subcommand. On `txn import` and `export` -- which each define
+//! their own `--format` carrying a *different* value enum -- the two
+//! definitions clashed. Accessing the subcommand's `format` then panicked with:
+//!
+//! ```text
+//! Mismatch between definition and access of `format`. Could not downcast to
+//! beankeeper_cli::cli::OutputFormat, need to downcast to ImportFormat
+//! ```
+//!
+//! The fix gives the subcommand options distinct clap ids and removes
+//! `global = true` from the output `--format`. These tests assert that
+//! invoking the affected subcommands no longer panics on the downcast.
+
+use std::error::Error;
+use std::path::Path;
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use tempfile::tempdir;
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+/// Convert a path to a UTF-8 `&str`, failing the test cleanly when it is not.
+fn path_str(path: &Path) -> Result<&str, Box<dyn Error>> {
+    path.to_str()
+        .ok_or_else(|| Box::<dyn Error>::from(format!("non-utf8 path: {}", path.display())))
+}
+
+/// Initialize a demo database (which creates the `acme-consulting` company with
+/// account code `1000`) inside a throwaway directory, returning that directory.
+fn init_demo_db() -> Result<tempfile::TempDir, Box<dyn Error>> {
+    let dir = tempdir()?;
+    let db_path = dir.path().join("books.db");
+
+    Command::cargo_bin("bk")?
+        .args(["init", "--demo", "--path", path_str(&db_path)?])
+        .assert()
+        .success();
+
+    Ok(dir)
+}
+
+/// The clap panic message that issue #10 reproduces. Any stream containing this
+/// indicates the downcast collision was hit.
+const DOWNCAST_PANIC: &str = "Mismatch between definition and access";
+
+/// Run a command and return stdout+stderr concatenated.
+fn run(args: &[&str], dir: &tempfile::TempDir) -> Result<String, Box<dyn Error>> {
+    let output = Command::cargo_bin("bk")?.args(args).current_dir(dir.path()).output()?;
+    let mut combined = String::from_utf8(output.stdout)?;
+    combined.push_str(&String::from_utf8(output.stderr)?);
+    Ok(combined)
+}
+
+#[test]
+fn txn_import_format_ofx_does_not_panic_on_arg_downcast() -> TestResult {
+    let dir = init_demo_db()?;
+    std::fs::write(
+        dir.path().join("stmt.ofx"),
+        "OFXHEADER:100\nDATA:OFXSGML\n\n<OFX></OFX>\n",
+    )?;
+
+    let combined = run(
+        &[
+            "--company",
+            "acme-consulting",
+            "--db",
+            "books.db",
+            "txn",
+            "import",
+            "--file",
+            "stmt.ofx",
+            "--format",
+            "ofx",
+            "--account",
+            "1000",
+            "--suspense",
+            "9000",
+        ],
+        &dir,
+    )?;
+
+    // Bug (#10): `--format ofx` on `txn import` panicked because the global
+    // OutputFormat `format` id collided with the ImportFormat one. The command
+    // may legitimately fail for other reasons, but it must not panic on the
+    // clap argument-id downcast.
+    assert!(
+        !combined.contains(DOWNCAST_PANIC),
+        "txn import --format ofx hit the clap arg-id downcast panic: {combined}"
+    );
+    Ok(())
+}
+
+#[test]
+fn export_format_does_not_panic_on_arg_downcast() -> TestResult {
+    let dir = init_demo_db()?;
+
+    let combined = run(
+        &["--db", "books.db", "export", "--format", "json"],
+        &dir,
+    )?;
+
+    // Bug (#10): `--format json` on `export` panicked because the global
+    // OutputFormat `format` id collided with the ExportFormat one.
+    assert!(
+        !combined.contains(DOWNCAST_PANIC),
+        "export --format json hit the clap arg-id downcast panic: {combined}"
+    );
+    // A clean export emits a JSON envelope; sanity-check we reached real logic.
+    assert!(
+        combined.contains("beankeeper_export"),
+        "export did not produce its JSON envelope: {combined}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes GitHub #10: `bk txn import --format ofx` (and `bk export --format ...`) panicked at runtime with

```
Mismatch between definition and access of `format`. Could not downcast to
OutputFormat, need to downcast to ImportFormat
```

### Root cause
The top-level output `--format` option was declared `global = true`, so its clap argument id (`format`) propagated onto every subcommand. `txn import` and `export` each define their own `--format` carrying a *different* value enum (`ImportFormat` / `ExportFormat`), so the two definitions collided and accessing the subcommand value panicked on the downcast.

### Fix
- Give the subcommand options distinct clap ids (`import_format` / `export_format`, both still spelled `--format`).
- Drop `global = true` from the top-level output `--format` so its long flag is no longer duplicated onto those subcommands. `--json` remains global.
- The output `--format`/`--json` options are now top-level only (place them *before* the subcommand, e.g. `bk --format csv txn list`). README examples updated accordingly.

`bk txn import --format ofx` no longer panics — it reaches real OFX-parsing logic. `bk export --format json` produces its JSON envelope as expected.

### Verification
- Two new integration tests assert `txn import --format ofx` and `export --format json` no longer hit the clap arg-id downcast panic.
- `cargo nextest run --workspace` => **442 tests run: 442 passed, 0 skipped** (includes the two #10 reproduction tests and the demo-data balance tests).
- `cargo clippy --workspace --all-targets` => **0 warnings / 0 errors**.

### Clippy debt
A second commit clears ~62 pre-existing deny-level `unwrap_used`/`expect_used` errors and pedantic warnings surfaced under `--all-targets` in unrelated modules — all resolved at the root (test-only unwrap/expect exempted via clippy's first-class `.clippy.toml` config; money literals regrouped to consistent 3-digit grouping; sign-losing `i32 as usize` casts replaced with checked `usize::try_from`; `Copy` enums passed by value; oversized functions decomposed into helpers). The only retained suppression is the documented `clippy::too_many_arguments` exception.

### Semver
Bumps `beankeeper-cli` 0.6.0 -> 0.7.0: dropping the post-subcommand `--format` placement is a backward-incompatible CLI grammar change, which under 0.x semver maps to a minor bump.

Closes #10